### PR TITLE
Fix for issues/5 : automatically re-initialize runtime arguments after adding custom argument

### DIFF
--- a/NST/src/main/java/com/ebay/runtime/RuntimeConfigManager.java
+++ b/NST/src/main/java/com/ebay/runtime/RuntimeConfigManager.java
@@ -56,9 +56,8 @@ public class RuntimeConfigManager {
 	}
 
 	/**
-	 * Add a custom runtime config option. You MUST call reinitialize() after the
-	 * last runtime argument is added to have the manager pickup those runtime
-	 * values, if specified by the user.
+	 * Add a custom runtime config option. This will call reinitialize() to have the
+	 * manager pickup those runtime values, if specified by the user.
 	 * 
 	 * If the runtime argument already exists the new one is ignored. Overriding
 	 * existing runtime arguments is NOT allowed.
@@ -71,6 +70,7 @@ public class RuntimeConfigManager {
 	public void addRuntimeArgument(RuntimeConfigValue<?> value) {
 		if (!arguments.containsKey(value.getRuntimeArgumentKey())) {
 			arguments.put(value.getRuntimeArgumentKey(), value);
+			reinitialize();
 		}
 	}
 

--- a/NST/src/test/java/com/ebay/runtime/RuntimeConfigManagerTest.java
+++ b/NST/src/test/java/com/ebay/runtime/RuntimeConfigManagerTest.java
@@ -462,9 +462,8 @@ public class RuntimeConfigManagerTest {
 	@Test
 	public void customArgumentOverride() {
 		
-		RuntimeConfigManager.getInstance().addRuntimeArgument(new CustomArgument());
 		System.setProperty(CustomArgument.KEY, "true");
-		RuntimeConfigManager.getInstance().reinitialize();
+		RuntimeConfigManager.getInstance().addRuntimeArgument(new CustomArgument());
 
 		CustomArgument argument = (CustomArgument) RuntimeConfigManager.getInstance().getRuntimeArgument(CustomArgument.KEY);
 		Boolean runtimeValue = argument.getRuntimeArgumentValue();

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
 		<maven.compiler.plugin.version>3.6.0</maven.compiler.plugin.version>
 		<maven.surefire.plugin.version>2.9</maven.surefire.plugin.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<nstest.version>1.0.0</nstest.version>
+		<nstest.version>1.0.1</nstest.version>
 		<testng.version>7.5</testng.version>
 		<maven.deploy.skip>true</maven.deploy.skip>
 	</properties>


### PR DESCRIPTION
* Updated RuntimeArgumentManager to adopt change
* Updated unit tests
* Updated release version of nstest