### PR TITLE
Camel case correctness for output files and checks and preventing empty string input

### DIFF
--- a/TMBuilder/src/main/java/com/ebay/tool/thinmodelgen/gui/checkeditor/builder/components/ListOfDoubleComponent.java
+++ b/TMBuilder/src/main/java/com/ebay/tool/thinmodelgen/gui/checkeditor/builder/components/ListOfDoubleComponent.java
@@ -204,6 +204,9 @@ public class ListOfDoubleComponent extends BaseComponent {
       @Override
       public void actionPerformed(ActionEvent e) {
         String text = doubleTextField.getText();
+        if (text.isEmpty()) {
+          return;
+        }
         doubleTextField.setText("");
         DefaultListModel<String> model = (DefaultListModel<String>) list.getModel();
         model.addElement(text);

--- a/TMBuilder/src/main/java/com/ebay/tool/thinmodelgen/gui/checkeditor/builder/components/ListOfIntegerComponent.java
+++ b/TMBuilder/src/main/java/com/ebay/tool/thinmodelgen/gui/checkeditor/builder/components/ListOfIntegerComponent.java
@@ -207,6 +207,9 @@ public class ListOfIntegerComponent extends BaseComponent {
       @Override
       public void actionPerformed(ActionEvent e) {
         String text = integerTextField.getText();
+        if (text.isEmpty()) {
+          return;
+        }
         integerTextField.setText("");
         DefaultListModel<String> model = (DefaultListModel<String>) list.getModel();
         model.addElement(text);

--- a/TMBuilder/src/main/java/com/ebay/tool/thinmodelgen/gui/checkeditor/builder/components/ListOfStringComponent.java
+++ b/TMBuilder/src/main/java/com/ebay/tool/thinmodelgen/gui/checkeditor/builder/components/ListOfStringComponent.java
@@ -204,6 +204,9 @@ public class ListOfStringComponent extends BaseComponent {
       @Override
       public void actionPerformed(ActionEvent e) {
         String text = inputField.getText();
+        if (text.isEmpty()) {
+          return;
+        }
         inputField.setText("");
         DefaultListModel<String> model = (DefaultListModel<String>) list.getModel();
         model.addElement(text);

--- a/TMBuilder/src/main/java/com/ebay/tool/thinmodelgen/gui/menu/export/DeveloperMockExport.java
+++ b/TMBuilder/src/main/java/com/ebay/tool/thinmodelgen/gui/menu/export/DeveloperMockExport.java
@@ -38,7 +38,10 @@ public class DeveloperMockExport {
 
             String json = getJsonFromValidationSet(coreValidationSet, validationSetModel);
 
-            String fileName = String.format(DEVELOPER_MOCK_FILE_NAME_FORMAT, validationSetModel.getValidationSetName());
+            String validationSetName = validationSetModel.getValidationSetName();
+            validationSetName = camelCaseValidationSetName(validationSetName);
+
+            String fileName = String.format(DEVELOPER_MOCK_FILE_NAME_FORMAT, validationSetName);
             File exportFile = new File(exportPath, fileName);
             FileWriter fileWriter = new FileWriter(exportFile);
             fileWriter.write(json);
@@ -89,5 +92,19 @@ public class DeveloperMockExport {
         }
 
         return null;
+    }
+
+    /**
+     * Apply camel casing to the first letter of the validation set name.
+     * @param validationSetName Validation set name to process.
+     * @return Validation set name with the first letter converted to upper case.
+     */
+    protected String camelCaseValidationSetName(String validationSetName) {
+        if (validationSetName.length() > 0) {
+            String firstCharacter = String.valueOf(validationSetName.charAt(0));
+            firstCharacter = firstCharacter.toUpperCase();
+            validationSetName = firstCharacter + validationSetName.substring(1);
+        }
+        return validationSetName;
     }
 }

--- a/TMBuilder/src/main/java/com/ebay/tool/thinmodelgen/gui/menu/export/ThinModelExport.java
+++ b/TMBuilder/src/main/java/com/ebay/tool/thinmodelgen/gui/menu/export/ThinModelExport.java
@@ -159,6 +159,20 @@ public class ThinModelExport {
     return getValidationStatementsForNodeModels(Arrays.asList(validationSetModel.getData()));
   }
 
+  /**
+   * Apply camel casing to the first letter of the validation set name.
+   * @param validationSetName Validation set name to process.
+   * @return Validation set name with the first letter converted to lower case.
+   */
+  protected String lowerCaseCamelCaseValidationSetName(String validationSetName) {
+    if (validationSetName.length() > 0) {
+      String firstCharacter = String.valueOf(validationSetName.charAt(0));
+      firstCharacter = firstCharacter.toLowerCase();
+      validationSetName = firstCharacter + validationSetName.substring(1);
+    }
+    return validationSetName;
+  }
+
   private String getValidationStatementsForNodeModels(List<NodeModel> nodeModels) throws IOException, ClassNotFoundException {
     StringBuilder methodBuilder = new StringBuilder();
     for (NodeModel nodeModel : nodeModels) {
@@ -196,7 +210,9 @@ public class ThinModelExport {
     StringBuilder allValidations = new StringBuilder();
 
     for (ValidationSetModel validationSetModel : validationSetModels) {
-      String methodSignature = validationSetModel.getValidationSetName() + "(SoftAssert softAssert)";
+      String validationSetName = validationSetModel.getValidationSetName();
+      validationSetName = lowerCaseCamelCaseValidationSetName(validationSetName);
+      String methodSignature =  validationSetName + "(SoftAssert softAssert)";
       allValidations.append(GENERATED_VALIDATIONS_START_BLOCK);
       allValidations.append("\n");
       allValidations.append(prepareMethodAndStatementsWithMethod(Arrays.asList(validationSetModel.getData()), methodSignature));

--- a/TMBuilder/src/test/java/com/ebay/tool/thinmodelgen/gui/menu/export/DeveloperMockExportTest.java
+++ b/TMBuilder/src/test/java/com/ebay/tool/thinmodelgen/gui/menu/export/DeveloperMockExportTest.java
@@ -51,4 +51,23 @@ public class DeveloperMockExportTest {
         assertThat(validations.size(), is(equalTo(1)));
         assertThat(validations.get(0).getValidationSetName(), is(equalTo("FOO")));
     }
+
+    @DataProvider(name = "camelCaseValidationSetNameTestValues")
+    public Object[][] camelCaseValidationSetNameTestValues() {
+        return new Object[][] {
+                { "", "" },
+                { "first", "First" },
+                { "a", "A" },
+                { "AA", "AA" },
+                { "aA", "AA" },
+                { "andBecause", "AndBecause" },
+                { "aa", "Aa" },
+        };
+    }
+
+    @Test(dataProvider = "camelCaseValidationSetNameTestValues")
+    public void camelCaseValidationSetName(String input, String expected) {
+        String actual = export.camelCaseValidationSetName(input);
+        assertThat(actual, is(equalTo(expected)));
+    }
 }

--- a/TMBuilder/src/test/java/com/ebay/tool/thinmodelgen/gui/menu/export/ThinModelExportTest.java
+++ b/TMBuilder/src/test/java/com/ebay/tool/thinmodelgen/gui/menu/export/ThinModelExportTest.java
@@ -8,6 +8,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import com.ebay.test.util.FileParser;
@@ -102,4 +103,24 @@ public class ThinModelExportTest {
 	    String actualFileContents = FileParser.readInFile(exportFile);
 	    assertThat("Generated file contents must match expected.", actualFileContents, is(equalTo(expectedFileContents)));
   }
+
+    @DataProvider(name = "lowerCaseCamelCaseValidationSetNameTestData")
+    public Object[][] lowerCaseCamelCaseValidationSetNameTestData() {
+        return new Object[][] {
+                { "", "" },
+                { "First", "first" },
+                { "a", "a" },
+                { "AA", "aA" },
+                { "aA", "aA" },
+                { "andBecause", "andBecause" },
+                { "Aa", "aa" },
+        };
+    }
+
+    @Test(dataProvider = "lowerCaseCamelCaseValidationSetNameTestData")
+    public void lowerCaseCamelCaseValidationSetName(String input, String expected) {
+        ThinModelExport export = new ThinModelExport();
+        String actual = export.lowerCaseCamelCaseValidationSetName(input);
+        assertThat(actual, is(equalTo(expected)));
+    }
 }


### PR DESCRIPTION
* Camel case correctness for mock JSON files - first letter to upper case
* Camel case correctness for thin model method names - first letter to lower case
* List of (string/integer/double) no longer allows an empty string to be added