### PR TITLE
v1.1.4 - update to disable response logging by runtime argument

### DIFF
--- a/NST/src/main/java/com/ebay/nst/NSTServiceWrapperProcessor.java
+++ b/NST/src/main/java/com/ebay/nst/NSTServiceWrapperProcessor.java
@@ -5,6 +5,7 @@ import java.net.URISyntaxException;
 import java.util.List;
 import java.util.Map;
 
+import com.ebay.runtime.arguments.DisableConsoleLog;
 import org.json.JSONObject;
 import org.testng.Reporter;
 
@@ -296,6 +297,10 @@ public final class NSTServiceWrapperProcessor {
 
 	protected void logResponseDetailsToConsole(NSTServiceWrapper<? extends NSTSchemaValidator> serviceWrapper,
 			NSTHttpResponse response) {
+
+		if (RuntimeConfigManager.getInstance().getDisableConsoleLogValues().contains(DisableConsoleLog.RESPONSE_PAYLOAD)) {
+			return;
+		}
 
 		if (response == null) {
 			Reporter.log("Response was null - skipping logging response details.", true);

--- a/NST/src/main/java/com/ebay/runtime/arguments/DisableConsoleLog.java
+++ b/NST/src/main/java/com/ebay/runtime/arguments/DisableConsoleLog.java
@@ -1,5 +1,11 @@
 package com.ebay.runtime.arguments;
 
+/**
+ * SERVICE_CONFIG may be used by adopters to turn off service configuration logging on their end.
+ * NSTest has no way to query adopter service configurations.
+ *
+ * RESPONSE_PAYLOAD disables all response logging by NSTest.
+ */
 public enum DisableConsoleLog {
 	NONE, RESPONSE_PAYLOAD, SERVICE_CONFIG;
 

--- a/NST/src/test/java/com/ebay/nst/NSTServiceWrapperProcessorTest.java
+++ b/NST/src/test/java/com/ebay/nst/NSTServiceWrapperProcessorTest.java
@@ -643,6 +643,42 @@ public class NSTServiceWrapperProcessorTest {
 	}
 
 	@Test
+	public void logResponseDetailsToConsoleWhenLoggingEnabled() {
+		System.setOut(new PrintStream(outputStreamCaptor));
+
+		String payload = "{ \"Foo\": \"bar\" }";
+
+		NSTServiceWrapper serviceWrapper = mock(NSTServiceWrapper.class);
+		when(serviceWrapper.getServiceWrapperConsoleOutput(Mockito.any(NSTHttpResponse.class))).thenReturn(null);
+
+		NSTHttpResponse response = mock(NSTHttpResponse.class);
+		when(response.getPayload()).thenReturn(payload);
+
+		processor = new NSTServiceWrapperProcessor();
+		processor.logResponseDetailsToConsole(serviceWrapper, response);
+		assertThat("Console does not contain expected output.", outputStreamCaptor.toString().trim(), containsString(payload));
+	}
+
+	@Test
+	public void doNotLogResponseDetailsToConsoleWhenLoggingDisabled() {
+		System.setOut(new PrintStream(outputStreamCaptor));
+		System.setProperty(DISABLE_LOG_TO_CONSOLE, "RESPONSE_PAYLOAD");
+		RuntimeConfigManager.getInstance().reinitialize();
+
+		String payload = "{ \"Foo\": \"bar\" }";
+
+		NSTServiceWrapper serviceWrapper = mock(NSTServiceWrapper.class);
+		when(serviceWrapper.getServiceWrapperConsoleOutput(Mockito.any(NSTHttpResponse.class))).thenReturn(null);
+
+		NSTHttpResponse response = mock(NSTHttpResponse.class);
+		when(response.getPayload()).thenReturn(payload);
+
+		processor = new NSTServiceWrapperProcessor();
+		processor.logResponseDetailsToConsole(serviceWrapper, response);
+		assertThat("Console contains unexpected output.", outputStreamCaptor.toString().trim(), not(containsString(payload)));
+	}
+
+	@Test
 	public void logResponseDetailsToConsoleWithNullResponse() {
 		System.setOut(new PrintStream(outputStreamCaptor));
 		NSTServiceWrapper serviceWrapper = mock(NSTServiceWrapper.class);

--- a/NSTTutorials/pom.xml
+++ b/NSTTutorials/pom.xml
@@ -37,7 +37,7 @@
         <maven.compiler.version>1.8</maven.compiler.version>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <maven.compiler.release>1.8</maven.compiler.release>
+<!--        <maven.compiler.release>1.8</maven.compiler.release>-->
         <maven.compiler.plugin.version>3.6.0</maven.compiler.plugin.version>
         <maven.surefire.plugin.version>2.9</maven.surefire.plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -15,10 +15,11 @@
 	</licenses>
 
 	<properties>
+		<java.version>1.8</java.version>
 		<maven.compiler.version>1.8</maven.compiler.version>
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>
-		<maven.compiler.release>1.8</maven.compiler.release>
+<!--		<maven.compiler.release>1.8</maven.compiler.release>-->
 		<maven.compiler.plugin.version>3.6.0</maven.compiler.plugin.version>
 		<maven.surefire.plugin.version>2.9</maven.surefire.plugin.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 		<maven.compiler.plugin.version>3.6.0</maven.compiler.plugin.version>
 		<maven.surefire.plugin.version>2.9</maven.surefire.plugin.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<nstest.version>1.1.3</nstest.version>
+		<nstest.version>1.1.4</nstest.version>
 		<testng.version>7.5</testng.version>
 		<maven.deploy.skip>true</maven.deploy.skip>
 	</properties>


### PR DESCRIPTION
* Disable console log runtime argument RESPONSE_PAYLOAD was not disabling logging of response details in NSTest
* Added documentation about SERVICE_CONFIG being available to adopters to use to disable custom service config logging on their end