### PR TITLE
Fix multi-threading usage of RuntimeConfigManager

### DIFF
--- a/NST/src/test/java/com/ebay/runtime/RuntimeConfigManagerTest.java
+++ b/NST/src/test/java/com/ebay/runtime/RuntimeConfigManagerTest.java
@@ -520,33 +520,31 @@ public class RuntimeConfigManagerTest {
 
 		new Thread(() -> {
 			RuntimeConfigManager first = RuntimeConfigManager.getInstance();
-			// Loop for two seconds (100 * 20 ms wait)
-			for (int i = 0; i < 100; i++) {
-				PlatformArgument platformArg = (PlatformArgument) first.getRuntimeArgument(PlatformArgument.KEY);
-				platformArg.override(Platform.SITE);
-				try {
-					Thread.sleep(20);
-				} catch (InterruptedException e) {
-					throw new RuntimeException(e);
-				}
-			}
+
 			PlatformArgument platformArg = (PlatformArgument) first.getRuntimeArgument(PlatformArgument.KEY);
+			platformArg.override(Platform.SITE);
+			try {
+				Thread.sleep(2000);
+			} catch (InterruptedException e) {
+				throw new RuntimeException(e);
+			}
+
+			platformArg = (PlatformArgument) first.getRuntimeArgument(PlatformArgument.KEY);
 			firstPlatform.set(platformArg.getRuntimeArgumentValue());
 		}).start();
 
 		new Thread(() -> {
 			RuntimeConfigManager second = RuntimeConfigManager.getInstance();
-			// Loop for two seconds (100 * 20 ms wait)
-			for (int i = 0; i < 100; i++) {
-				PlatformArgument platformArg = (PlatformArgument) second.getRuntimeArgument(PlatformArgument.KEY);
-				platformArg.override(Platform.ANDROID);
-				try {
-					Thread.sleep(20);
-				} catch (InterruptedException e) {
-					throw new RuntimeException(e);
-				}
-			}
+
 			PlatformArgument platformArg = (PlatformArgument) second.getRuntimeArgument(PlatformArgument.KEY);
+			platformArg.override(Platform.ANDROID);
+			try {
+				Thread.sleep(20);
+			} catch (InterruptedException e) {
+				throw new RuntimeException(e);
+			}
+
+			platformArg = (PlatformArgument) second.getRuntimeArgument(PlatformArgument.KEY);
 			secondPlatform.set(platformArg.getRuntimeArgumentValue());
 		}).start();
 

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
 		<maven.compiler.plugin.version>3.6.0</maven.compiler.plugin.version>
 		<maven.surefire.plugin.version>2.9</maven.surefire.plugin.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<nstest.version>1.1.5</nstest.version>
+		<nstest.version>1.1.6</nstest.version>
 		<testng.version>7.5</testng.version>
 		<maven.deploy.skip>true</maven.deploy.skip>
 	</properties>


### PR DESCRIPTION
* RuntimeConfigManager singleton was causing variability in the test excecution when tests are run in parallel.
* This was caused by reinitialize operations between tests and overrides performed for a specific test.
* Adopted ThreadLocal to tie instances of RuntimeConfigManager to a thread without having to change access to RuntimeConfigManager getInstance().
* Added test to confirm override values can be set by separate threads and preserved.