### PR TITLE
CustomLoggerFormatManager InvocationTargetException handling

### DIFF
--- a/NST/src/main/java/com/ebay/service/logger/formats/loader/CustomLoggerFormatManager.java
+++ b/NST/src/main/java/com/ebay/service/logger/formats/loader/CustomLoggerFormatManager.java
@@ -112,8 +112,11 @@ public class CustomLoggerFormatManager {
 						FormatWriter formatWriter = (FormatWriter) constructor.newInstance();
 						platformWriters.put(formatWriter.getPlatformAssociation(), formatWriter);
 						break;
-					} catch (InstantiationException | IllegalAccessException | IllegalArgumentException
-							| InvocationTargetException e) {
+					} catch (InstantiationException | IllegalAccessException | IllegalArgumentException e) {
+						e.printStackTrace();
+						break;
+					} catch (InvocationTargetException e) {
+						e.getTargetException().printStackTrace();
 						e.printStackTrace();
 						break;
 					}

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
 		<maven.compiler.plugin.version>3.6.0</maven.compiler.plugin.version>
 		<maven.surefire.plugin.version>2.9</maven.surefire.plugin.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<nstest.version>1.1.6</nstest.version>
+		<nstest.version>1.1.7</nstest.version>
 		<testng.version>7.5</testng.version>
 		<maven.deploy.skip>true</maven.deploy.skip>
 	</properties>


### PR DESCRIPTION
* By not getting the target exceptioni from the InvocationTargetException we were not able to surface the correct messaging coming from initializing a logger instance using reflection.
* Capture InvocationTargetException separately and surface the target exception stack trace and exception stack trace to the console.