### PR TITLE
Enable RuntimeConfig overrides in Before and After methods

### DIFF
--- a/NST/src/main/java/com/ebay/nst/NSTServiceTestRunner.java
+++ b/NST/src/main/java/com/ebay/nst/NSTServiceTestRunner.java
@@ -34,9 +34,6 @@ public interface NSTServiceTestRunner extends IHookable {
 		String startTestCase = "TestNG:Start %s";
 		String endTestCase = "TestNG:End %s";
 
-		// Clear all overrides.
-		RuntimeConfigManager.getInstance().reinitialize();
-
 		Reporter.setCurrentTestResult(iTestResult);
 
 		String methodName = iTestResult.getMethod().getMethodName();
@@ -50,6 +47,11 @@ public interface NSTServiceTestRunner extends IHookable {
 		TestExecutionEventManager.getInstance().notifyBeforeTestMethodObserver(payload);
 
 		hookCallback.runTestMethod(iTestResult);
+
+		// Clear all runtime overrides.
+		// This needs to occur after the test method executes to enable the use of
+		// @beforeMethod to setup overrides before teach test method executes.
+		RuntimeConfigManager.getInstance().reinitialize();
 
 		// The latest updates to TestNG seem to have modified the ITestResult status handling.
 		// These are set for the timeout variants of invokeMethod*(). runTestMethod() calls

--- a/NST/src/test/java/com/ebay/nst/NSTServiceTestRunnerTest.java
+++ b/NST/src/test/java/com/ebay/nst/NSTServiceTestRunnerTest.java
@@ -1,0 +1,66 @@
+package com.ebay.nst;
+
+import com.ebay.nst.hosts.manager.PoolType;
+import com.ebay.runtime.RuntimeConfigManager;
+import com.ebay.runtime.arguments.Platform;
+import com.ebay.runtime.arguments.PlatformArgument;
+import com.ebay.runtime.arguments.PoolTypeArgument;
+import com.ebay.softassert.EbaySoftAssert;
+import org.testng.annotations.*;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+
+public class NSTServiceTestRunnerTest implements NSTServiceTestRunner {
+
+    @Override
+    public EbaySoftAssert getSoftAssert() {
+        return null;
+    }
+
+    // Do this as cleanup - not part of the test evaluations
+    @AfterClass
+    public void doLast() {
+        RuntimeConfigManager.getInstance().reinitialize();
+    }
+
+    @Test
+    public void testCaseOverridePoolType() {
+
+        PoolType poolType = RuntimeConfigManager.getInstance().getPoolType();
+        assertThat(poolType, is(equalTo(PoolType.QA)));
+        PoolTypeArgument poolTypeArgument = (PoolTypeArgument) RuntimeConfigManager.getInstance().getRuntimeArgument(PoolTypeArgument.KEY);
+        poolTypeArgument.override(PoolType.PROD);
+        poolType = RuntimeConfigManager.getInstance().getPoolType();
+        assertThat(poolType, is(equalTo(PoolType.PROD)));
+    }
+
+    // Follows up after testCaseOverridePoolType() has run and confirms we are reset to QA poo.
+    // No other tests should use the PoolType argument besides these two test cases.
+    @Test(dependsOnMethods = { "testCaseOverridePoolType" })
+    public void testCaseOverridePoolTypeVerifyReset() {
+        PoolType poolType = RuntimeConfigManager.getInstance().getPoolType();
+        assertThat(poolType, is(equalTo(PoolType.QA)));
+    }
+
+    @BeforeMethod
+    public void beforeMethodOverride() {
+        Platform platform = RuntimeConfigManager.getInstance().getPlatform();
+        assertThat(platform, is(equalTo(Platform.IOS)));
+        PlatformArgument argument = (PlatformArgument) RuntimeConfigManager.getInstance().getRuntimeArgument(PlatformArgument.KEY);
+        argument.override(Platform.ANDROID);
+    }
+
+    @Test
+    public void testBeforeMethodOverride() {
+        Platform platform = RuntimeConfigManager.getInstance().getPlatform();
+        assertThat(platform, is(equalTo(Platform.ANDROID)));
+    }
+
+    @Test
+    public void testBeforeMethodOverrideSecondTime() {
+        Platform platform = RuntimeConfigManager.getInstance().getPlatform();
+        assertThat(platform, is(equalTo(Platform.ANDROID)));
+    }
+}


### PR DESCRIPTION
* Placement of the RuntimeConfigManager reinitialize was just before the test method executes. This prevented the use of BeforeMethod to setup common overrides.
* Moving RuntimeConfigManager reinitialize to immediately after the test method executes to support BeforeMethod overrides.