### PR TITLE
v1.1.13 : Add support for parsing with newline added after each line parsed form the response body.

### DIFF
--- a/.github/workflows/java-ci.yml
+++ b/.github/workflows/java-ci.yml
@@ -1,7 +1,5 @@
 name: Java CI
 run-name: Triggering execution of Java tests
-permissions:
-  actions: write
 on:
   push:
     branches:
@@ -11,6 +9,11 @@ on:
 jobs:
   run-tests:
     runs-on: ubuntu-latest
+    permissions:
+      checks: write
+      contents: read
+      issues: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@v3
       - name: Set up JDK 8

--- a/.github/workflows/java-ci.yml
+++ b/.github/workflows/java-ci.yml
@@ -1,5 +1,7 @@
 name: Java CI
 run-name: Triggering execution of Java tests
+permissions:
+  actions: write
 on:
   push:
     branches:

--- a/NST/src/main/java/com/ebay/service/protocol/http/NSTHttpClientImpl.java
+++ b/NST/src/main/java/com/ebay/service/protocol/http/NSTHttpClientImpl.java
@@ -27,6 +27,16 @@ import com.ebay.nst.NstRequestType;
 
 public class NSTHttpClientImpl implements NSTHttpClient<NSTHttpRequest, NSTHttpResponse> {
 
+	private boolean addNewlineWhenParsingResponse = false;
+
+	/**
+	 * Set to true to add a new line after each line parsed from the response payload. Default is false.
+	 * @param addNewlineWhenParsingResponse True to add a new line after each line parsed from the response payload. Default is false.
+	 */
+	public void setAddNewlineWhenParsingResponse(boolean addNewlineWhenParsingResponse) {
+		this.addNewlineWhenParsingResponse = addNewlineWhenParsingResponse;
+	}
+
 	@Override
 	public NSTHttpResponse sendRequest(NSTHttpRequest request) {
 		return sendRequest(request, StandardCharsets.UTF_8);
@@ -157,6 +167,9 @@ public class NSTHttpClientImpl implements NSTHttpClient<NSTHttpRequest, NSTHttpR
 		StringBuffer content = new StringBuffer();
 		while ((inputLine = in.readLine()) != null) {
 			content.append(inputLine);
+			if (addNewlineWhenParsingResponse) {
+				content.append("\n");
+			}
 		}
 		in.close();
 		response.setPayload(content.toString());

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 		<maven.compiler.plugin.version>3.6.0</maven.compiler.plugin.version>
 		<maven.surefire.plugin.version>2.9</maven.surefire.plugin.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<nstest.version>1.1.12</nstest.version>
+		<nstest.version>1.1.13</nstest.version>
 		<testng.version>7.5</testng.version>
 		<maven.deploy.skip>true</maven.deploy.skip>
 	</properties>


### PR DESCRIPTION
* Typically not necessary for structured responses like JSON or XML.
* For raw parsing, for example of GitHub get content API, it is a necessary option.
* Increment release version.