### PR TITLE
Issue 48 : Support OpenAPISchemaValidator's use of Swagger's ParseOptions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,6 @@
 *.tar.gz
 *.rar
 *.har
-*.json
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*

--- a/NST/src/main/java/com/ebay/nst/schema/validation/OpenApiSchemaValidator.java
+++ b/NST/src/main/java/com/ebay/nst/schema/validation/OpenApiSchemaValidator.java
@@ -5,6 +5,8 @@ import com.ebay.nst.schema.validation.support.SchemaValidationException;
 import com.ebay.nst.schema.validation.support.SchemaValidatorUtil;
 import com.ebay.openapi.export.jsonschema.OpenApiToJsonSchema;
 import com.fasterxml.jackson.databind.JsonNode;
+import io.swagger.v3.parser.core.models.ParseOptions;
+
 import java.util.Objects;
 
 /**
@@ -51,6 +53,7 @@ public class OpenApiSchemaValidator implements NSTRestSchemaValidator {
 	private final boolean allowAdditionalProperties;
 	private final StatusCode statusCode;
 	private final Payload payload;
+	private final ParseOptions parseOptions;
 
 	/**
 	 * Initialize the OpenAPI validator with the following values.
@@ -62,7 +65,7 @@ public class OpenApiSchemaValidator implements NSTRestSchemaValidator {
 	 * @param requestMethod             Request method to apply from the schema definition.
 	 * @param allowAdditionalProperties Allow properties which are not in the schema definition
 	 */
-	private OpenApiSchemaValidator(String schemaResourcePath, String schemaPath, NstRequestType requestMethod, AllowAdditionalProperties allowAdditionalProperties, Payload payload, StatusCode statusCode) {
+	private OpenApiSchemaValidator(String schemaResourcePath, String schemaPath, NstRequestType requestMethod, AllowAdditionalProperties allowAdditionalProperties, Payload payload, StatusCode statusCode, ParseOptions parseOptions) {
 		this.schemaResourcePath = Objects.requireNonNull(schemaResourcePath, "Schema resource path cannot be null.");
 		this.schemaPath = Objects.requireNonNull(schemaPath, "Schema path cannot be null.");
 		this.requestMethod = Objects.requireNonNull(requestMethod, "Request method cannot be null.");
@@ -73,13 +76,14 @@ public class OpenApiSchemaValidator implements NSTRestSchemaValidator {
 		}
 		this.payload = payload;
 		this.statusCode = statusCode;
+		this.parseOptions = parseOptions;
 	}
 
 	@Override
 	public void validate(String responseBody) throws SchemaValidationException {
 
 		OpenApiToJsonSchema openApiToJsonSchema = new OpenApiToJsonSchema(schemaResourcePath, schemaPath,
-				requestMethod, allowAdditionalProperties, payload.getValue(), statusCode.getValue());
+				requestMethod, allowAdditionalProperties, payload.getValue(), statusCode.getValue(), parseOptions);
 		openApiToJsonSchema.convert();
 		JsonNode jsonSchema = openApiToJsonSchema.getJsonSchema();
 
@@ -102,6 +106,7 @@ public class OpenApiSchemaValidator implements NSTRestSchemaValidator {
 		private AllowAdditionalProperties allowAdditionalProperties = AllowAdditionalProperties.YES;
 		private Payload payload = Payload.RESPONSE;
 		private StatusCode statusCode = StatusCode._200;
+		private ParseOptions parseOptions;
 
 		public Builder(String schemaResourcePath, String schemaPath, NstRequestType requestMethod) {
 			this.schemaResourcePath = Objects.requireNonNull(schemaResourcePath, "Schema resource path cannot be null.");
@@ -145,6 +150,16 @@ public class OpenApiSchemaValidator implements NSTRestSchemaValidator {
 		}
 
 		/**
+		 * Set the swagger parsing options. See: https://github.com/swagger-api/swagger-parser/tree/master?tab=readme-ov-file#options
+		 * @param parseOptions Parsing options to use.
+		 * @return Builder instance.
+		 */
+		public Builder setParseOptions(ParseOptions parseOptions) {
+			this.parseOptions = parseOptions;
+			return this;
+		}
+
+		/**
 		 * Create a new OpenApiSchemaValidator instance based on the builder
 		 * configuration.
 		 * 
@@ -152,7 +167,7 @@ public class OpenApiSchemaValidator implements NSTRestSchemaValidator {
 		 */
 		public OpenApiSchemaValidator build() {
 			return new OpenApiSchemaValidator(schemaResourcePath, schemaPath, requestMethod, allowAdditionalProperties,
-					payload, statusCode);
+					payload, statusCode, parseOptions);
 		}
 	}
 

--- a/NST/src/main/java/com/ebay/openapi/export/jsonschema/OpenApiToJsonSchema.java
+++ b/NST/src/main/java/com/ebay/openapi/export/jsonschema/OpenApiToJsonSchema.java
@@ -38,6 +38,7 @@ public class OpenApiToJsonSchema {
 	private final List<EbaySchemaTransformer> transformers;
 	private final boolean useRequestModel;
 	private final String statusCode;
+	private final ParseOptions parseOptions;
 
 	/**
 	 * Convert an OpenAPI yaml spec to JSON schema. Call 'convert()' to begin the
@@ -54,6 +55,25 @@ public class OpenApiToJsonSchema {
 	 * @param statusCode				Response code to use.
 	 */
 	public OpenApiToJsonSchema(String openApiSpecFilePath, String requestPath, NstRequestType requestMethod, boolean allowAdditionalProperties, boolean useRequestModel, String statusCode) {
+		this(openApiSpecFilePath, requestPath, requestMethod, allowAdditionalProperties, useRequestModel, statusCode, new ParseOptions());
+	}
+
+	/**
+	 * Convert an OpenAPI yaml spec to JSON schema. Call 'convert()' to begin the
+	 * operation.
+	 *
+	 * @param openApiSpecFilePath       Path to yaml spec to convert.
+	 * @param requestPath               The API request path to evaluate in the schema.
+	 * @param requestMethod             Request method corresponding to the requestPath to
+	 *                                  evaluate.
+	 * @param allowAdditionalProperties when false, validation will fail if properties are
+	 *                                  present which are not defined in the schema
+	 * @param useRequestModel 			True to use the request model path, false to use the
+	 * 									response model path.
+	 * @param statusCode				Response code to use.
+	 * @param parseOptions				Swagger parsing options to use.
+	 */
+	public OpenApiToJsonSchema(String openApiSpecFilePath, String requestPath, NstRequestType requestMethod, boolean allowAdditionalProperties, boolean useRequestModel, String statusCode, ParseOptions parseOptions) {
 		this.openApiSpecFilePath = openApiSpecFilePath;
 		this.requestPath = requestPath;
 		this.requestMethod = requestMethod;
@@ -61,21 +81,11 @@ public class OpenApiToJsonSchema {
 		this.useRequestModel = useRequestModel;
 		this.statusCode = statusCode;
 		this.transformers = createTransformers();
-	}
-
-	/**
-	 * Convert an OpenAPI yaml spec to JSON schema. Call 'convert()' to begin the
-	 * operation.
-	 *
-	 * @param openApiSpecFilePath Path to yaml spec to convert.
-	 * @param requestPath         The API request path to evaluate in the schema.
-	 * @param requestMethod       Request method corresponding to the requestPath to
-	 *                            evaluate.
-	 * @deprecated use {@link OpenApiToJsonSchema#OpenApiToJsonSchema(String, String, NstRequestType, boolean, boolean, String	)}}
-	 */
-	@Deprecated
-	public OpenApiToJsonSchema(String openApiSpecFilePath, String requestPath, NstRequestType requestMethod) {
-		this(openApiSpecFilePath, requestPath, requestMethod, true, false, "200");
+		if (parseOptions != null) {
+			this.parseOptions = parseOptions;
+		} else {
+			this.parseOptions = new ParseOptions();
+		}
 	}
 
 	/**
@@ -107,9 +117,7 @@ public class OpenApiToJsonSchema {
 	 */
 	public void convert() {
 
-		// Parse the OpenAPI yaml
-		ParseOptions options = new ParseOptions();
-		SwaggerParseResult parseResult = new OpenAPIV3Parser().readLocation(openApiSpecFilePath, null, options);
+		SwaggerParseResult parseResult = new OpenAPIV3Parser().readLocation(openApiSpecFilePath, null, parseOptions);
 		if (parseResult == null || parseResult.getOpenAPI() == null) {
 			throw new IllegalStateException("Unable to read yaml file from path: " + openApiSpecFilePath);
 		}

--- a/NST/src/test/java/com/ebay/nst/schema/validation/OpenApiSchemaValidatorTest.java
+++ b/NST/src/test/java/com/ebay/nst/schema/validation/OpenApiSchemaValidatorTest.java
@@ -1,0 +1,88 @@
+package com.ebay.nst.schema.validation;
+
+import com.ebay.nst.NstRequestType;
+import com.ebay.nst.schema.validation.support.SchemaValidationException;
+import com.ebay.utility.ResourceParser;
+import io.swagger.v3.parser.core.models.ParseOptions;
+import org.testng.annotations.Test;
+
+public class OpenApiSchemaValidatorTest {
+
+    @Test
+    public void schemaValidatePassWithRelativePathRefs() throws Exception {
+
+        ParseOptions parseOptions = new ParseOptions();
+        parseOptions.setResolve(true);
+
+        OpenApiSchemaValidator validator = new OpenApiSchemaValidator.Builder("/com/ebay/nst/schema/validation/OpenApiSchemaValidatorTest/schema/root.yaml", "/test", NstRequestType.GET)
+                .allowAdditionalProperties(OpenApiSchemaValidator.AllowAdditionalProperties.NO).setParseOptions(parseOptions)
+                .build();
+
+        String testResponsePayload = ResourceParser.readInResourceFile("/com/ebay/nst/schema/validation/OpenApiSchemaValidatorTest/json/validResponse.json");
+
+        validator.validate(testResponsePayload);
+    }
+
+    @Test
+    public void schemaValidatePassWithAllLocalReferences() throws Exception {
+
+        OpenApiSchemaValidator validator = new OpenApiSchemaValidator.Builder("/com/ebay/nst/schema/validation/OpenApiSchemaValidatorTest/schema/singleRootDocumentWithReferences.yaml", "/test", NstRequestType.GET)
+                .allowAdditionalProperties(OpenApiSchemaValidator.AllowAdditionalProperties.NO)
+                .build();
+
+        String testResponsePayload = ResourceParser.readInResourceFile("/com/ebay/nst/schema/validation/OpenApiSchemaValidatorTest/json/validResponse.json");
+
+        validator.validate(testResponsePayload);
+    }
+
+    @Test
+    public void schemaValidatePassEverythingInline() throws Exception {
+
+        OpenApiSchemaValidator validator = new OpenApiSchemaValidator.Builder("/com/ebay/nst/schema/validation/OpenApiSchemaValidatorTest/schema/singleRootDocumentInlined.yaml", "/test", NstRequestType.GET)
+                .allowAdditionalProperties(OpenApiSchemaValidator.AllowAdditionalProperties.NO)
+                .build();
+
+        String testResponsePayload = ResourceParser.readInResourceFile("/com/ebay/nst/schema/validation/OpenApiSchemaValidatorTest/json/validResponse.json");
+
+        validator.validate(testResponsePayload);
+    }
+
+    @Test(expectedExceptions = SchemaValidationException.class)
+    public void schemaValidateFailWithRelativePathRefs() throws Exception {
+
+        ParseOptions parseOptions = new ParseOptions();
+        parseOptions.setResolve(true);
+
+        OpenApiSchemaValidator validator = new OpenApiSchemaValidator.Builder("/com/ebay/nst/schema/validation/OpenApiSchemaValidatorTest/schema/root.yaml", "/test", NstRequestType.GET)
+                .allowAdditionalProperties(OpenApiSchemaValidator.AllowAdditionalProperties.NO).setParseOptions(parseOptions)
+                .build();
+
+        String testResponsePayload = ResourceParser.readInResourceFile("/com/ebay/nst/schema/validation/OpenApiSchemaValidatorTest/json/invalidResponse.json");
+
+        validator.validate(testResponsePayload);
+    }
+
+    @Test(expectedExceptions = SchemaValidationException.class)
+    public void schemaValidateFailWithAllLocalReferences() throws Exception {
+
+        OpenApiSchemaValidator validator = new OpenApiSchemaValidator.Builder("/com/ebay/nst/schema/validation/OpenApiSchemaValidatorTest/schema/singleRootDocumentWithReferences.yaml", "/test", NstRequestType.GET)
+                .allowAdditionalProperties(OpenApiSchemaValidator.AllowAdditionalProperties.NO)
+                .build();
+
+        String testResponsePayload = ResourceParser.readInResourceFile("/com/ebay/nst/schema/validation/OpenApiSchemaValidatorTest/json/invalidResponse.json");
+
+        validator.validate(testResponsePayload);
+    }
+
+    @Test(expectedExceptions = SchemaValidationException.class)
+    public void schemaValidateFailEverythingInline() throws Exception {
+
+        OpenApiSchemaValidator validator = new OpenApiSchemaValidator.Builder("/com/ebay/nst/schema/validation/OpenApiSchemaValidatorTest/schema/singleRootDocumentInlined.yaml", "/test", NstRequestType.GET)
+                .allowAdditionalProperties(OpenApiSchemaValidator.AllowAdditionalProperties.NO)
+                .build();
+
+        String testResponsePayload = ResourceParser.readInResourceFile("/com/ebay/nst/schema/validation/OpenApiSchemaValidatorTest/json/invalidResponse.json");
+
+        validator.validate(testResponsePayload);
+    }
+}

--- a/NST/src/test/resources/com/ebay/nst/schema/validation/OpenApiSchemaValidatorTest/json/invalidResponse.json
+++ b/NST/src/test/resources/com/ebay/nst/schema/validation/OpenApiSchemaValidatorTest/json/invalidResponse.json
@@ -1,0 +1,23 @@
+{
+  "numberOfFruit": 100,
+  "typesOfApples": [
+    {
+      "name": "Fuji",
+      "color": 1
+    },
+    {
+      "name": "Gala",
+      "color": "YELLOW"
+    }
+  ],
+  "typesOfBananas": [
+    {
+      "name": "Big Yellow",
+      "color": "YELLOW"
+    },
+    {
+      "name": "Old Brown",
+      "color": 2
+    }
+  ]
+}

--- a/NST/src/test/resources/com/ebay/nst/schema/validation/OpenApiSchemaValidatorTest/json/validResponse.json
+++ b/NST/src/test/resources/com/ebay/nst/schema/validation/OpenApiSchemaValidatorTest/json/validResponse.json
@@ -1,0 +1,23 @@
+{
+  "numberOfFruit": 100,
+  "typesOfApples": [
+    {
+      "name": "Fuji",
+      "color": "RED"
+    },
+    {
+      "name": "Gala",
+      "color": "YELLOW"
+    }
+  ],
+  "typesOfBananas": [
+    {
+      "name": "Big Yellow",
+      "color": "YELLOW"
+    },
+    {
+      "name": "Old Brown",
+      "color": "BROWN"
+    }
+  ]
+}

--- a/NST/src/test/resources/com/ebay/nst/schema/validation/OpenApiSchemaValidatorTest/schema/root.yaml
+++ b/NST/src/test/resources/com/ebay/nst/schema/validation/OpenApiSchemaValidatorTest/schema/root.yaml
@@ -1,0 +1,36 @@
+openapi: 3.0.0
+info:
+  title: Root Schema
+  description: >-
+    Root Schema
+  version: 1.0.0
+servers:
+  - url: 'http://ebay.com'
+    description: QATE
+paths:
+  /test:
+    get:
+      summary: placeholder summary
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TestResponse'
+components:
+  schemas:
+    TestResponse:
+      type: object
+      properties:
+        numberOfFruit:
+          type: integer
+          format: int32
+        typesOfApples:
+          type: array
+          items:
+            $ref: "types.yaml#/components/schemas/Apple"
+        typesOfBananas:
+          type: array
+          items:
+            $ref: "types.yaml#/components/schemas/Banana"

--- a/NST/src/test/resources/com/ebay/nst/schema/validation/OpenApiSchemaValidatorTest/schema/singleRootDocumentInlined.yaml
+++ b/NST/src/test/resources/com/ebay/nst/schema/validation/OpenApiSchemaValidatorTest/schema/singleRootDocumentInlined.yaml
@@ -1,0 +1,54 @@
+openapi: 3.0.0
+info:
+  title: Root Schema
+  description: >-
+    Root Schema
+  version: 1.0.0
+servers:
+  - url: 'http://ebay.com'
+    description: QATE
+paths:
+  /test:
+    get:
+      summary: placeholder summary
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TestResponse'
+components:
+  schemas:
+    TestResponse:
+      type: object
+      properties:
+        numberOfFruit:
+          type: integer
+          format: int32
+        typesOfApples:
+          type: array
+          items:
+            type: object
+            properties:
+              name:
+                type: string
+              color:
+                type: string
+                enum:
+                  - RED
+                  - GREEN
+                  - YELLOW
+        typesOfBananas:
+          type: array
+          items:
+            type: object
+            properties:
+              name:
+                type: string
+              color:
+                type: string
+                enum:
+                  - YELLOW
+                  - GREEN
+                  - BROWN

--- a/NST/src/test/resources/com/ebay/nst/schema/validation/OpenApiSchemaValidatorTest/schema/singleRootDocumentWithReferences.yaml
+++ b/NST/src/test/resources/com/ebay/nst/schema/validation/OpenApiSchemaValidatorTest/schema/singleRootDocumentWithReferences.yaml
@@ -1,0 +1,58 @@
+openapi: 3.0.0
+info:
+  title: Root Schema
+  description: >-
+    Root Schema
+  version: 1.0.0
+servers:
+  - url: 'http://ebay.com'
+    description: QATE
+paths:
+  /test:
+    get:
+      summary: placeholder summary
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TestResponse'
+components:
+  schemas:
+    TestResponse:
+      type: object
+      properties:
+        numberOfFruit:
+          type: integer
+          format: int32
+        typesOfApples:
+          type: array
+          items:
+            $ref: "#/components/schemas/Apple"
+        typesOfBananas:
+          type: array
+          items:
+            $ref: "#/components/schemas/Banana"
+    Apple:
+      type: object
+      properties:
+        name:
+          type: string
+        color:
+          type: string
+          enum:
+            - RED
+            - GREEN
+            - YELLOW
+    Banana:
+      type: object
+      properties:
+        name:
+          type: string
+        color:
+          type: string
+          enum:
+            - YELLOW
+            - GREEN
+            - BROWN

--- a/NST/src/test/resources/com/ebay/nst/schema/validation/OpenApiSchemaValidatorTest/schema/types.yaml
+++ b/NST/src/test/resources/com/ebay/nst/schema/validation/OpenApiSchemaValidatorTest/schema/types.yaml
@@ -1,0 +1,44 @@
+openapi: 3.0.0
+info:
+  title: Type Definitions
+  description: >-
+    Type Definitions
+  version: 1.0.0
+servers:
+  - url: 'http://ebay.com'
+    description: QATE
+paths:
+  /test:
+    get:
+      summary: placeholder summary
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Apple'
+components:
+  schemas:
+    Apple:
+      type: object
+      properties:
+        name:
+          type: string
+        color:
+          type: string
+          enum:
+            - RED
+            - GREEN
+            - YELLOW
+    Banana:
+      type: object
+      properties:
+        name:
+          type: string
+        color:
+          type: string
+          enum:
+            - YELLOW
+            - GREEN
+            - BROWN

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 		<maven.compiler.plugin.version>3.6.0</maven.compiler.plugin.version>
 		<maven.surefire.plugin.version>2.9</maven.surefire.plugin.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<nstest.version>1.1.13</nstest.version>
+		<nstest.version>1.2.0</nstest.version>
 		<testng.version>7.5</testng.version>
 		<maven.deploy.skip>true</maven.deploy.skip>
 	</properties>


### PR DESCRIPTION
* [Issue 48](https://github.com/eBay/NSTSuite/issues/48)
* Support inclusion of Swagger's ParseOptions in OpenApiSchemaValidator's builder.