### PR TITLE
Fixed REST/GraphQL tutorials links

### DIFF
--- a/NST/README.md
+++ b/NST/README.md
@@ -9,8 +9,8 @@ The output format of the mocks and service client may be overridden for customiz
 
 See REST and GraphQL examples in the test packages:  
 
-* [REST](../NSTTutorials/src/test/java/com/nst/tutorials/rest)
-* [GraphQL](../NSTTutorials/src/test/java/com/nst/tutorials/graphql)
+* [REST](../NSTTutorials)
+* [GraphQL](../NSTTutorials/GraphQLExamples/src/main/java/com/ebay/nst/tutorials/graphql)
 
 NST has test runner hooks for TestNG so please plan to adopt TestNG for your tests.
 


### PR DESCRIPTION
Fixed links for the tutorials. We could also create `REST` and `GraphQL` folders inside `NSTTutorials` but so far all REST examples are clearly grouped/stated in README.