### PR TITLE
Upgrading NST to use v1.1.4 of the GraphQL to JSON schema library. Updated release version of NST to 1.2.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 		<maven.compiler.plugin.version>3.6.0</maven.compiler.plugin.version>
 		<maven.surefire.plugin.version>2.9</maven.surefire.plugin.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<nstest.version>1.2.2</nstest.version>
+		<nstest.version>1.2.3</nstest.version>
 		<testng.version>7.5</testng.version>
 		<maven.deploy.skip>true</maven.deploy.skip>
 	</properties>
@@ -93,7 +93,7 @@
 		<dependency>
 			<groupId>com.ebay.nst</groupId>
 			<artifactId>graphql-to-jsonschema</artifactId>
-			<version>1.1.3</version>
+			<version>1.1.4</version>
 		</dependency>
 		<dependency>
 			<groupId>org.json</groupId>


### PR DESCRIPTION
Adopt these changes to the GraphQL to JSON schema library: https://github.com/eBay/GraphQL2JSONSchema/pull/17